### PR TITLE
Add SPDX headers and update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +181,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +189,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 NVIDIA Corporation
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- add Apache-2.0 SPDX headers to Python scripts
- update the root LICENSE file with the NVIDIA Apache 2.0 license text

## Notes
- SPDX headers are inserted after shebang and Python encoding declarations where present.